### PR TITLE
Update code to match -03 draft version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ conditions in the LICENSE file.
 ## Protocol compatibility
 
 The DNS-over-QUIC implementation follows
-[draft-ietf-dprive-dnsoquic-02](https://datatracker.ietf.org/doc/draft-ietf-dprive-dnsoquic).
+[draft-ietf-dprive-dnsoquic-03](https://datatracker.ietf.org/doc/draft-ietf-dprive-dnsoquic).
 
 The QUIC protocol compatibility depends on the
 [quic-go](https:///github.com/lucas-clemente/quic-go) library.
@@ -35,17 +35,18 @@ openssl req -x509 -days 30 -subj "/CN=DNS-over-QUIC Test" -addext "subjectAltNam
 
 Start the proxy. By default, the server loads the TLS key and certificate from
 the files generated above, will use 8.8.4.4 (Google Public DNS) as a backend
-server, and will listen on UDP port 8853. Use command line options to modify
-the default behavior. Notice the use of the default port requries starting the
-proxy as superuser.
+server, and will listen on UDP port 784 (experimental port from the draft). Use
+command line options to modify the default behavior. Notice the use of the
+default port requires starting the proxy as superuser.
 
 ```
 sudo ./proxy
 ```
 
-Query the proxy using the testing utility. The client establishes a QUIC session
-to the server and sends each query via a dedicated stream. The replies are printed
-in the order of completion:
+Query the proxy using the testing utility. The client establishes a QUIC
+session to the server and sends each query via a dedicated stream. Upstream, the
+XFR requests are sent over TCP, all others are sent over UDP. The replies are
+printed in the order of completion:
 
 ```
 ./client ns1.com A ns1.com AAAA
@@ -97,7 +98,7 @@ The proxy also logs information about accepted connections and streams which
 can be used to inspect the sequence of events:
 
 ```
-$ sudo ./proxy -listen 127.0.0.1:784 -cert cert.pem -key key.pem -udp_backend 8.8.4.4:53
+$ sudo ./proxy -listen 127.0.0.1:784 -cert cert.pem -key key.pem -backend 8.8.4.4:53
 ts=2019-03-24T10:31:32.408891Z msg="listening for clients" addr=127.0.0.1:784
 ts=2019-03-24T12:16:45.048583Z client=127.0.0.1:52212 msg="session accepted"
 ts=2019-03-24T12:16:45.050231Z client=127.0.0.1:52212 stream_id=0 msg="stream accepted"

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -22,11 +22,11 @@ type Query struct {
 
 func main() {
 	var (
-		server     string
-		dnssec     bool
-		recursion  bool
-		exportkeys bool
-		queries    []Query
+		server    string
+		dnssec    bool
+		recursion bool
+		keysPath  string
+		queries   []Query
 	)
 
 	flag.Usage = func() {
@@ -37,7 +37,7 @@ func main() {
 	flag.StringVar(&server, "server", "127.0.0.1:784", "DNS-over-QUIC server to use.")
 	flag.BoolVar(&dnssec, "dnssec", true, "Send DNSSEC OK flag.")
 	flag.BoolVar(&recursion, "recursion", true, "Send RD flag.")
-	flag.BoolVar(&exportkeys, "exportkeys", false, "Export session keys to file sessionkeys.txt for decryption")
+	flag.StringVar(&keysPath, "export_keys_path", "", "File name to export session keys for decryption.")
 	flag.Parse()
 
 	if flag.NArg() == 0 || flag.NArg()%2 != 0 {
@@ -61,10 +61,10 @@ func main() {
 	}
 
 	var keyLog io.Writer
-	if exportkeys {
-		w, err := os.OpenFile("sessionkeys.txt", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if keysPath != "" {
+		w, err := os.OpenFile(keysPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Could not create file sessionkeys.txt\n")
+			fmt.Fprintf(os.Stderr, "failed to open file for session keys: %s\n", err)
 		}
 		defer w.Close()
 		keyLog = w

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -21,6 +21,10 @@ type Query struct {
 }
 
 func main() {
+	os.Exit(main2())
+}
+
+func main2() int {
 	var (
 		server    string
 		dnssec    bool
@@ -42,7 +46,7 @@ func main() {
 
 	if flag.NArg() == 0 || flag.NArg()%2 != 0 {
 		flag.Usage()
-		os.Exit(1)
+		return 1
 	}
 
 	for i := 0; (i + 1) < flag.NArg(); i += 2 {
@@ -50,7 +54,7 @@ func main() {
 		qtype, ok := dns.StringToType[flag.Arg(i+1)]
 		if !ok {
 			fmt.Fprintf(os.Stderr, "invalid qtype: %s\n", flag.Arg(i+1))
-			os.Exit(1)
+			return 1
 		}
 		if qtype == dns.TypeIXFR {
 			// TODO: Allow user to pass in serial number for IXFR
@@ -65,6 +69,7 @@ func main() {
 		w, err := os.OpenFile(keysPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to open file for session keys: %s\n", err)
+			return 1
 		}
 		defer w.Close()
 		keyLog = w
@@ -78,7 +83,7 @@ func main() {
 	session, err := quic.DialAddr(server, &tls, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to connect to the server: %s\n", err)
-		os.Exit(1)
+		return 1
 	}
 	defer session.CloseWithError(0, "") // TODO: Is this how the session should be closed?
 
@@ -105,6 +110,8 @@ func main() {
 	for p := range print {
 		fmt.Println(p)
 	}
+
+	return 0
 }
 
 func SendQuery(session quic.Session, query *Query, dnssec, recursion bool, print chan (string)) error {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -170,6 +170,4 @@ func SendQuery(session quic.Session, query *Query, dnssec, recursion bool, print
 			return nil
 		}
 	}
-
-	return nil
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"crypto/tls"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -145,7 +145,7 @@ func SendQuery(session quic.Session, query *Query, dnssec, recursion bool, print
 		stream.SetDeadline(time.Now().Add(time.Second))
 		if err := binary.Read(stream, binary.BigEndian, &length); err != nil {
 			// Ignore timeout related errors as this is how we close this connection for now
-			if strings.Contains(err.Error(), "deadline") {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
 				return nil
 			}
 			return fmt.Errorf("read length from QUIC connection: %w", err)

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -34,7 +34,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	flag.StringVar(&server, "server", "127.0.0.1:8853", "DNS-over-QUIC server to use.")
+	flag.StringVar(&server, "server", "127.0.0.1:784", "DNS-over-QUIC server to use.")
 	flag.BoolVar(&dnssec, "dnssec", true, "Send DNSSEC OK flag.")
 	flag.BoolVar(&recursion, "recursion", true, "Send RD flag.")
 	flag.BoolVar(&exportkeys, "exportkeys", false, "Export session keys to file sessionkeys.txt for decryption")
@@ -52,8 +52,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "invalid qtype: %s\n", flag.Arg(i+1))
 			os.Exit(1)
 		}
-
-		queries = append(queries, Query{qname, qtype})
+		if qtype == dns.TypeIXFR {
+			// TODO: Allow user to pass in serial number for IXFR
+			fmt.Fprintf(os.Stderr, "skipping unsupported qtype: %s\n", flag.Arg(i+1))
+		} else {
+			queries = append(queries, Query{qname, qtype})
+		}
 	}
 
 	var keyLog io.Writer


### PR DESCRIPTION
This is a proof of concept for updating this code to match the -03 version of the draft:
- Use a 2 byte msg length
- Enforce MsgID=0 on QUIC connections
- Forward AXFRs upstream over TCP (TODO: IXFR support ).
- Support multiple responses for AXFR on a single stream using a crude timeout to close connections
