### PR TITLE
Update dependencies, use RFC9000 QUIC

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -77,7 +77,7 @@ func main2() int {
 
 	tls := tls.Config{
 		InsecureSkipVerify: true,
-		NextProtos:         []string{"doq-i03"},
+		NextProtos:         []string{"doq"},
 		KeyLogWriter:       keyLog,
 	}
 	session, err := quic.DialAddr(server, &tls, nil)
@@ -114,7 +114,7 @@ func main2() int {
 	return 0
 }
 
-func SendQuery(session quic.Session, query *Query, dnssec, recursion bool, print chan (string)) error {
+func SendQuery(session quic.Connection, query *Query, dnssec, recursion bool, print chan (string)) error {
 	stream, err := session.OpenStream()
 	if err != nil {
 		return fmt.Errorf("open stream: %w", err)

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -84,7 +84,7 @@ func loop(l log.Logger, ctx context.Context) error {
 
 	tls := tls.Config{
 		Certificates: []tls.Certificate{cert},
-		NextProtos:   []string{"doq-i03"},
+		NextProtos:   []string{"doq"},
 	}
 
 	listener, err := quic.ListenAddr(addr, &tls, nil)
@@ -114,7 +114,7 @@ func loop(l log.Logger, ctx context.Context) error {
 
 }
 
-func handleClient(l log.Logger, ctx context.Context, session quic.Session, backend string) {
+func handleClient(l log.Logger, ctx context.Context, session quic.Connection, backend string) {
 	l.Log("msg", "session accepted")
 
 	var (

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,33 @@
 module github.com/ns1/doq-proxy
 
-go 1.13
+go 1.17
 
 require (
-	github.com/go-kit/kit v0.10.0
-	github.com/lucas-clemente/quic-go v0.19.3
-	github.com/miekg/dns v1.1.40
+	github.com/go-kit/kit v0.12.0
+	github.com/lucas-clemente/quic-go v0.27.0
+	github.com/miekg/dns v1.1.48
 	github.com/oklog/run v1.1.0
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
+	golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
+)
+
+require (
+	github.com/cheekybits/genny v1.0.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-kit/log v0.2.0 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
+	github.com/marten-seemann/qtls-go1-16 v0.1.5 // indirect
+	github.com/marten-seemann/qtls-go1-17 v0.1.1 // indirect
+	github.com/marten-seemann/qtls-go1-18 v0.1.1 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/onsi/ginkgo v1.16.4 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/crypto v0.0.0-20210915214749-c084706c2272 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf // indirect
+	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
Dependent libraries updated, DoQ now works according to current DoQ draft and according to QUIC RFC9000/9001.

I'm not sure about the additional dependencies added by `go mod tidy`. Please sort that out. Sorry for that.